### PR TITLE
This PR was a mistake. It does not contain the correct file changes.

### DIFF
--- a/transactions/repository/transactions_repository.py
+++ b/transactions/repository/transactions_repository.py
@@ -1,11 +1,14 @@
+from typing import List
 from transactions.transactions_service.transactions import Transaction
-
 
 class TransactionsRepository:
     def __init__(self):
         self.database = []
-
+    
     def add(self) -> Transaction:
         transaction = Transaction()
         self.database.append(transaction)
         return transaction
+    
+    def list(self) -> List[Transaction]:
+        return self.database

--- a/transactions/transactions_service/transactions_service.py
+++ b/transactions/transactions_service/transactions_service.py
@@ -1,10 +1,17 @@
 from transactions.repository.transactions_repository import TransactionsRepository
 from transactions.transactions_service.transactions import Transaction
 
-
 class TransactionsService:
     def __init__(self, transactions_repository: TransactionsRepository):
         self.transactions_repository = transactions_repository
-
+    
+    def get_transaction(self):
+        pass
+    
     def create_transaction(self) -> Transaction:
         return self.transactions_repository.add()
+    
+    def list_transactions(self):
+        return self.transactions_repository.list()
+    
+    


### PR DESCRIPTION
The TransactionsService currently utilises an in-memory persistence object, TransactionsRepository. In the future, this will be refactored to utilise a database, or a new TransactionDatabaseRepository object will be created. This is possible because the TransactionsService and TransactionsRepository are loosely coupled: you parametrise the TransactionService with whichever repository object you prefer.

The feature is tested by showing that when two transactions are created by the transactions service they can subsequently be listed by the transactions service.