### PR TITLE
feat(transactions): persist Transactions created by TransactionsService

### DIFF
--- a/transactions/tests/test_transactions.py
+++ b/transactions/tests/test_transactions.py
@@ -1,13 +1,21 @@
 import pytest
 
-from transactions.transactions_service.transactions_service import TransactionsService
-from transactions.transactions_service.transactions import Transaction
 from transactions.repository.transactions_repository import TransactionsRepository
+from transactions.transactions_service.transactions import Transaction
+from transactions.transactions_service.transactions_service import TransactionsService
+
 
 @pytest.fixture(scope="function")
 def transactions_service():
     return TransactionsService(TransactionsRepository())
 
+
 def test_that_transactions_service_creates_transactions(transactions_service):
     transaction = transactions_service.create_transaction()
     assert isinstance(transaction, Transaction)
+
+
+def test_that_transactions_service_persists_created_transactions(transactions_service):
+    transaction1 = transactions_service.create_transaction()
+    transaction2 = transactions_service.create_transaction()
+    assert transactions_service.list_transactions() == [transaction1, transaction2]

--- a/transactions/transactions_service/transactions_service.py
+++ b/transactions/transactions_service/transactions_service.py
@@ -8,3 +8,6 @@ class TransactionsService:
 
     def create_transaction(self) -> Transaction:
         return self.transactions_repository.add()
+
+    def list_transactions(self):
+        return self.transactions_repository.list()


### PR DESCRIPTION
This feature is tested by showing that when two transactions are created by the TransactionsSerivice they can subsequently be listed by the TransactionsService.

Persistence is currently in-memory. This behaviour can be changed by modifying the TransactionsRepository object.